### PR TITLE
Add .babelrc to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 src/
+.babelrc


### PR DESCRIPTION
Hi. It's again me. Thanks for update trashable, it works now.
There is the same issue with this package in React Native.