### PR TITLE
Update flow types to support 0.89 HOC

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "eslint-plugin-flowtype": "^2.39.1",
     "eslint-plugin-jest": "^21.2.0",
     "eslint-plugin-react": "^7.4.0",
-    "flow-bin": "^0.59.0",
+    "flow-bin": "^0.89.0",
     "flow-copy-source": "^1.2.1",
     "husky": "^0.14.3",
     "jest": "^21.2.1",

--- a/src/index.js
+++ b/src/index.js
@@ -2,13 +2,21 @@
 import React from 'react';
 import makeTrashable from 'trashable';
 
-import type { ComponentType } from 'react';
+import type { AbstractComponent } from 'react';
 import type { TrashablePromise } from 'trashable';
+
+type RegisterPromiseType = <T>(promise: Promise<T>) => TrashablePromise<T>;
+
+export type TrashableReactProps = {
+  registerPromise: RegisterPromiseType,
+};
 
 type Key = number;
 
-const makeComponentTrashable = (Component: ComponentType<*>) => {
-  class TrashableComponent extends React.Component<*> {
+function makeComponentTrashable<Config: *>(
+  Component: AbstractComponent<Config>
+): AbstractComponent<$Diff<Config, TrashableReactProps>> {
+  class TrashableComponent extends React.Component<Config> {
     promiseStore = {};
     key: Key = 0;
 
@@ -31,7 +39,9 @@ const makeComponentTrashable = (Component: ComponentType<*>) => {
       delete this.promiseStore[key];
     };
 
-    registerPromise = <T>(promise: Promise<T>): TrashablePromise<T> => {
+    registerPromise: RegisterPromiseType = <T>(
+      promise: Promise<T>
+    ): TrashablePromise<T> => {
       const trashablePromise = makeTrashable(promise);
       const key = this.addPromise(trashablePromise);
 
@@ -61,7 +71,7 @@ const makeComponentTrashable = (Component: ComponentType<*>) => {
   }
   TrashableComponent.displayName = `Trashable(${getDisplayName(Component)})`;
   return TrashableComponent;
-};
+}
 
 function getDisplayName(WrappedComponent) {
   return WrappedComponent.displayName || WrappedComponent.name || 'Component';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1680,9 +1680,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.59.0:
-  version "0.59.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.59.0.tgz#8c151ee7f09f1deed9bf0b9d1f2e8ab9d470f1bb"
+flow-bin@^0.89.0:
+  version "0.89.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.89.0.tgz#6bd29c2af7e0f429797f820662f33749105c32fa"
 
 flow-copy-source@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
The new version of flow introduced an official syntax for supporting HOC flow types.
https://flow.org/en/docs/react/hoc/

The new way of doing this with flow is as follows:
```jsx
import trashable, { type TrashableReactProps } from 'trashable-react';

class Example extends React.Component<Props & TrashableReactProps> {
  ...as normal, flow should work as expected
}

export default trashable(Example);
```

Related PR in `trashable`: https://github.com/hjylewis/trashable/pull/11